### PR TITLE
Remove pywinauto dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "pyperclip>=1.9.0",
   "pyrect>=0.2.0",
   "PyScreeze>=1.0.1",
-  "pywinauto>=0.6.9",
   "scikit-image>=0.25.2",
   "opencv-python-headless>=4.12"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ pymsgbox>=1.0.9
 pyperclip>=1.9.0
 pyrect>=0.2.0
 PyScreeze>=1.0.1
-pywinauto>=0.6.9
 scikit-image>=0.25.2
 opencv-python-headless>=4.12
 packaging>=24


### PR DESCRIPTION
## Summary
- remove unneeded pywinauto dependency from project configuration and requirements

## Testing
- `pip install -r requirements.txt`
- `python tests/utest/run_tests.py`
- ⚠️ `python tests/atest/run_tests.py` (fails: KeyError: 'DISPLAY')

------
https://chatgpt.com/codex/tasks/task_e_68accd378b608333a6eb5fcac7bd60df