### PR TITLE
Make matplotlib optional via debug extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ python3 -m pip install robotframework-imagehorizonlibrary
 
 This will automatically install dependencies as well as their dependencies.
 
+If you want to use the optional Image Debugger that relies on matplotlib,
+install the library with the ``debug`` extra:
+
+```
+python3 -m pip install "robotframework-imagehorizonlibrary[debug]"
+```
+
 ### Windows
 
 ImageHorizonLibrary should work on Windows "out-of-the-box". Just run the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">=3.9"
 
 dependencies = [
   "robotframework>=7.0",
-  "matplotlib>=3.10",
   "Pillow>=11.3",
   "pyautogui>=0.9.54",
   "pygetwindow>=0.0.9",
@@ -26,6 +25,12 @@ dependencies = [
   "pywinauto>=0.6.9",
   "scikit-image>=0.25.2",
   "opencv-python-headless>=4.12"
+]
+
+[project.optional-dependencies]
+# Dependencies used only when running the optional debug GUI
+debug = [
+  "matplotlib>=3.10"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 robotframework>=7.0
-matplotlib>=3.10
 Pillow>=11.3
 pyautogui>=0.9.54
 pygetwindow>=0.0.9

--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -187,13 +187,22 @@ class UILocatorController:
 
     def on_click_plot_results_skimage(self):
         """Display detailed edge detection results in a matplotlib window."""
-        title = f"{self.view.matches_found.get()} matches (confidence: {self.image_horizon_instance.confidence})"
-        self.model.plot_result(
-            self.image_container.get_needle_image(ImageFormat.NUMPYARRAY),
-            self.image_container.get_haystack_image_orig_size(ImageFormat.NUMPYARRAY),
-            self.image_horizon_instance.needle_edge,
-            self.image_horizon_instance.haystack_edge,
-            self.image_horizon_instance.peakmap,
-            title,
-            self.coord
+        title = (
+            f"{self.view.matches_found.get()} matches (confidence: "
+            f"{self.image_horizon_instance.confidence})"
+        )
+        try:
+            self.model.plot_result(
+                self.image_container.get_needle_image(ImageFormat.NUMPYARRAY),
+                self.image_container.get_haystack_image_orig_size(
+                    ImageFormat.NUMPYARRAY
+                ),
+                self.image_horizon_instance.needle_edge,
+                self.image_horizon_instance.haystack_edge,
+                self.image_horizon_instance.peakmap,
+                title,
+                self.coord,
             )
+        except ImportError as exc:
+            # Provide feedback if the optional debug dependencies are missing
+            self.view.hint_msg.set(str(exc))

--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_model.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_model.py
@@ -1,10 +1,10 @@
 """Model layer used by the image debugger GUI."""
 
+import importlib
 import pyautogui as ag
-import matplotlib.pyplot as mplt
 
 
-class UILocatorModel():
+class UILocatorModel:
     """Encapsulates data operations for the debugger."""
 
     def capture_desktop(self):
@@ -13,13 +13,37 @@ class UILocatorModel():
 
     def change_color_of_label(self, num_of_matches_found) -> str:
         """Return a colour based on number of matches."""
-        if(num_of_matches_found == 1):
-            return 'green'
+        if num_of_matches_found == 1:
+            return "green"
         else:
-            return 'red'
+            return "red"
 
-    def plot_result(self, needle_img, haystack_img, needle_img_edges, haystack_img_edges, peakmap, title, coord):
-        """Visualise matching results using matplotlib."""
+    def plot_result(
+        self,
+        needle_img,
+        haystack_img,
+        needle_img_edges,
+        haystack_img_edges,
+        peakmap,
+        title,
+        coord,
+    ):
+        """Visualise matching results using matplotlib.
+
+        Raises:
+            ImportError: If :mod:`matplotlib` is not installed. Install the
+                optional ``debug`` extra using
+                ``pip install robotframework-imagehorizonlibrary[debug]``.
+        """
+        try:
+            mplt = importlib.import_module("matplotlib.pyplot")
+        except ModuleNotFoundError as exc:
+            raise ImportError(
+                "matplotlib is required for plotting debug results. "
+                "Install robotframework-imagehorizonlibrary[debug] to enable "
+                "this feature."
+            ) from exc
+
         fig, axs = mplt.subplots(2, 3)
         sp_haystack_img = axs[0, 0]
         sp_needle_img = axs[0, 1]
@@ -27,11 +51,11 @@ class UILocatorModel():
         sp_haystack_img_edges = axs[1, 0]
         sp_needle_img_edges = axs[1, 1]
         sp_peakmap = axs[1, 2]
-        
+
         # ROW 1 ================================
-        sp_needle_img.set_title('Needle')
+        sp_needle_img.set_title("Needle")
         sp_needle_img.imshow(needle_img, cmap=mplt.cm.gray)
-        sp_haystack_img.set_title('Haystack')
+        sp_haystack_img.set_title("Haystack")
         sp_haystack_img.imshow(haystack_img, cmap=mplt.cm.gray)
         sp_haystack_img.sharex(sp_haystack_img_edges)
         sp_haystack_img.sharey(sp_haystack_img_edges)
@@ -39,22 +63,25 @@ class UILocatorModel():
         sp_invisible.set_visible(False)
 
         # ROW 2 ================================
-        sp_needle_img_edges.set_title('Needle (edge d.)')
-        sp_needle_img_edges.imshow(needle_img_edges, cmap=mplt.cm.gray)    
+        sp_needle_img_edges.set_title("Needle (edge d.)")
+        sp_needle_img_edges.imshow(needle_img_edges, cmap=mplt.cm.gray)
 
-        sp_haystack_img_edges.set_title('Haystack (edge d.)')
+        sp_haystack_img_edges.set_title("Haystack (edge d.)")
         sp_haystack_img_edges.imshow(haystack_img_edges, cmap=mplt.cm.gray)
 
-        sp_peakmap.set_title('Peakmap')
+        sp_peakmap.set_title("Peakmap")
         sp_peakmap.imshow(peakmap)
         sp_peakmap.sharex(sp_haystack_img_edges)
         sp_peakmap.sharey(sp_haystack_img_edges)
-        
+
         for loc in coord:
-            rect = mplt.Rectangle((loc[0], loc[1]), loc[2], loc[3], edgecolor='r', facecolor='none')
+            rect = mplt.Rectangle(
+                (loc[0], loc[1]), loc[2], loc[3], edgecolor="r", facecolor="none"
+            )
             sp_haystack_img_edges.add_patch(rect)
-        
-        sp_peakmap.autoscale(False)    
-        fig.suptitle(title, fontsize=14, fontweight='bold')
-        
+
+        sp_peakmap.autoscale(False)
+        fig.suptitle(title, fontsize=14, fontweight="bold")
+
         mplt.show()
+


### PR DESCRIPTION
## Summary
- move matplotlib to optional `debug` extra
- lazily import matplotlib in the Image Debugger so core works without it
- document optional installation using `[debug]`

## Testing
- `python tests/utest/run_tests.py`
- `python tests/atest/run_tests.py` *(fails: Importing library 'ImageHorizonLibrary' failed: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_68acce42546c833391cde088316aaa92