### PR TITLE
chore: ignore common macOS system folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,19 @@
+# macOS system files
 .DS_Store
+.AppleDouble
+.LSOverride
+._*
+__MACOSX/
+.DocumentRevisions-V100/
+.fseventsd/
+.Spotlight-V100/
+.TemporaryItems/
+.Trashes/
+.AppleDB/
+.AppleDesktop/
+Network Trash Folder/
+Temporary Items/
+.apdisk
 
 # Virtual environments
 .venv/


### PR DESCRIPTION
## Summary
- ignore typical macOS metadata folders and files

## Testing
- `python tests/utest/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68b179cacbec8333b0cb076294f86389