### PR TITLE
Avoid ambiguous numpy truth value in does_exist

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -465,7 +465,8 @@ class _RecognizeImages(object):
         """
         with self._suppress_keyword_on_failure():
             try:
-                return bool(self._locate(reference_image, log_it=True))
+                self._locate(reference_image, log_it=True)
+                return True
             except ImageNotFoundException:
                 return False
 

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -89,6 +89,10 @@ class TestRecognizeImages(TestCase):
             self.assertFalse(self.lib.does_exist('my_picture'))
             self.assertEqual(len(run_on_failure.mock_calls), 0)
 
+    def test_does_exist_when_locate_returns_array(self):
+        with patch(self._locate, return_value=np.array([0, 0, 10, 10])):
+            self.assertTrue(self.lib.does_exist('my_picture'))
+
     def test_wait_for_happy_path(self):
         from ImageHorizonLibrary import InvalidImageException
         run_on_failure = MagicMock()


### PR DESCRIPTION
## Summary
- Avoid calling `bool()` on `_locate` return values in `does_exist`
- Add regression test to ensure array results do not raise errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b184366ae483339aba90631f2e7e13