### PR TITLE
fix: handle non-string image names

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -67,7 +67,7 @@ class _RecognizeImages(object):
             raise ReferenceFolderException(
                 "Reference folder is invalid: " '"%s"' % self.reference_folder
             )
-        if not path or not isinstance(path, str):
+        if not isinstance(path, str) or path == "":
             raise InvalidImageException('"%s" is invalid image name.' % path)
         path = str(path.lower().replace(" ", "_"))
         path = abspath(path_join(self.reference_folder, path))

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -227,7 +227,14 @@ class TestRecognizeImages(TestCase):
     def test_locate_with_invalid_image_name(self):
         from ImageHorizonLibrary import InvalidImageException
 
-        for invalid_image_name in (None, 123, 1.2, True, self.lib.__class__()):
+        for invalid_image_name in (
+            None,
+            123,
+            1.2,
+            True,
+            self.lib.__class__(),
+            np.array(["foo", "bar"]),
+        ):
             with self.assertRaises(InvalidImageException):
                 self.lib.locate(invalid_image_name)
 


### PR DESCRIPTION
## Summary
- avoid ambiguous truth value errors by validating non-string image names
- test invalid names including numpy arrays

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1937cd4108333bac32f5a547dfc79