### PR TITLE
Remove unused needle_img_name variable from CV2 strategy

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -784,7 +784,6 @@ class _StrategyCv2:
         confidence = ih.confidence or self._CV_DEFAULT_CONFIDENCE
         with ih._suppress_keyword_on_failure():
             needle_img = cv2.imread(ref_image, cv2.IMREAD_GRAYSCALE)
-            needle_img_name = ref_image.split("\\")[-1].split(".")[0]
             if haystack_image is None:
                 haystack_img_gray = cv2.cvtColor(
                     np.array(ag.screenshot()), cv2.COLOR_RGB2GRAY


### PR DESCRIPTION
## Summary
- Remove unused `needle_img_name` assignment from `_StrategyCv2._try_locate`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b693a2f2548333bf503b8063eebbd6