### PR TITLE
Handle string edge parameters in ImageHorizonLibrary

### DIFF
--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -257,13 +257,32 @@ class ImageHorizonLibrary(
         self.initial_confidence = confidence
         self._class_bases = inspect.getmro(self.__class__)
         self.set_strategy(strategy, self.confidence)
-        self.edge_sigma = edge_sigma
-        self.edge_low_threshold = edge_low_threshold
-        self.edge_high_threshold = edge_high_threshold
+        try:
+            self.edge_sigma = float(edge_sigma) if edge_sigma is not None else None
+        except (TypeError, ValueError):
+            self.edge_sigma = None
+        try:
+            self.edge_low_threshold = (
+                float(edge_low_threshold) if edge_low_threshold is not None else None
+            )
+        except (TypeError, ValueError):
+            self.edge_low_threshold = None
+        try:
+            self.edge_high_threshold = (
+                float(edge_high_threshold) if edge_high_threshold is not None else None
+            )
+        except (TypeError, ValueError):
+            self.edge_high_threshold = None
         self.edge_preprocess = edge_preprocess
-        self.edge_kernel_size = edge_kernel_size
+        try:
+            self.edge_kernel_size = int(edge_kernel_size)
+        except (TypeError, ValueError):
+            self.edge_kernel_size = 3
         self.validate_match = validate_match
-        self.validation_margin = validation_margin
+        try:
+            self.validation_margin = int(validation_margin)
+        except (TypeError, ValueError):
+            self.validation_margin = 5
 
         # multi-scale search configuration
         self.scale_enabled = False
@@ -305,13 +324,32 @@ class ImageHorizonLibrary(
             self.strategy_instance = _StrategyPyautogui(self)
         elif strategy == "edge":
             self.strategy_instance = _StrategyCv2(self)
-            self.edge_sigma = edge_sigma
-            self.edge_low_threshold = edge_low_threshold
-            self.edge_high_threshold = edge_high_threshold
+            try:
+                self.edge_sigma = float(edge_sigma) if edge_sigma is not None else None
+            except (TypeError, ValueError):
+                self.edge_sigma = None
+            try:
+                self.edge_low_threshold = (
+                    float(edge_low_threshold) if edge_low_threshold is not None else None
+                )
+            except (TypeError, ValueError):
+                self.edge_low_threshold = None
+            try:
+                self.edge_high_threshold = (
+                    float(edge_high_threshold) if edge_high_threshold is not None else None
+                )
+            except (TypeError, ValueError):
+                self.edge_high_threshold = None
             self.edge_preprocess = edge_preprocess
-            self.edge_kernel_size = edge_kernel_size
+            try:
+                self.edge_kernel_size = int(edge_kernel_size)
+            except (TypeError, ValueError):
+                self.edge_kernel_size = 3
             self.validate_match = validate_match
-            self.validation_margin = validation_margin
+            try:
+                self.validation_margin = int(validation_margin)
+            except (TypeError, ValueError):
+                self.validation_margin = 5
         else:
             raise StrategyException('Invalid strategy: "%s"' % strategy)
 

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -994,6 +994,12 @@ class _StrategyCv2:
         sigma = self.ih_instance.edge_sigma
         low = self.ih_instance.edge_low_threshold
         high = self.ih_instance.edge_high_threshold
+        try:
+            sigma = float(sigma) if sigma is not None else None
+            low = float(low) if low is not None else None
+            high = float(high) if high is not None else None
+        except (TypeError, ValueError):
+            sigma = low = high = None
 
         if sigma is None or low is None or high is None:
             auto_sigma, auto_low, auto_high = self._auto_edge_parameters(img)

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -362,6 +362,29 @@ class TestEdgeDetection(TestCase):
 
         self.assertFalse(np.array_equal(edges_low_high, edges_high_high))
 
+    def test_set_strategy_accepts_string_edge_parameters(self):
+        from unittest.mock import MagicMock, patch
+        import numpy as np
+
+        with patch.dict("sys.modules", {"pyautogui": MagicMock(), "cv2": MagicMock()}):
+            from ImageHorizonLibrary import ImageHorizonLibrary
+            from ImageHorizonLibrary.recognition._recognize_images import _StrategyCv2
+
+            ih = ImageHorizonLibrary(reference_folder=TESTIMG_DIR)
+
+        dummy_img = np.zeros((5, 5), dtype=np.uint8)
+        with patch.object(_StrategyCv2, "_detect_edges", return_value=dummy_img):
+            ih.set_strategy(
+                "edge",
+                edge_sigma="2.0",
+                edge_low_threshold="0.1",
+                edge_high_threshold="0.3",
+            )
+            ih.strategy_instance.detect_edges(dummy_img)
+            self.assertIsInstance(ih.edge_sigma, float)
+            self.assertIsInstance(ih.edge_low_threshold, float)
+            self.assertIsInstance(ih.edge_high_threshold, float)
+
 
 class TestMultiScaleSearch(TestCase):
     def test_finds_scaled_reference(self):


### PR DESCRIPTION
## Summary
- Parse edge detection parameters to floats/ints when setting strategies or initializing the library
- Ensure detect_edges gracefully converts parameter types
- Add regression test for passing edge parameters as strings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69708efe0833383cb3066cf3e4a7f