### PR TITLE
Set edge default confidence to 0.8

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -33,7 +33,7 @@ class UILocatorController:
         self.view.scale_sigma_edge.set(1.0)
         self.view.scale_low_thres_edge.set(0.1)
         self.view.scale_high_thres_edge.set(0.3)
-        self.view.scale_conf_lvl_edge.set(0.99)
+        self.view.scale_conf_lvl_edge.set(0.8)
         self.view.matches_found.set("None")
         self.view.btn_edge_detec_debugger["state"] = "disabled"
         self.view.btn_run_pyautogui["state"] = "disabled"

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -784,7 +784,7 @@ class _StrategyPyautogui:
 class _StrategyCv2:
     """Image matching strategy using OpenCV edge detection."""
 
-    _CV_DEFAULT_CONFIDENCE = 0.99
+    _CV_DEFAULT_CONFIDENCE = 0.8
 
     def __init__(self, image_horizon_instance):
         """Store reference to the owning ImageHorizonLibrary instance."""


### PR DESCRIPTION
## Summary
- Reduce default edge confidence threshold to 0.8
- Align debugger UI with new edge confidence default

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6a209b07c8333b84fc1986656a1db