### PR TITLE
Improve not-found image diagnostics

### DIFF
--- a/src/ImageHorizonLibrary/errors.py
+++ b/src/ImageHorizonLibrary/errors.py
@@ -4,11 +4,48 @@ class ImageHorizonLibraryError(ImportError):
 
 
 class ImageNotFoundException(Exception):
-    def __init__(self, image_name):
+    def __init__(
+        self,
+        image_name,
+        matches=0,
+        best_score=None,
+        confidence=None,
+    ):
+        """Describe missing reference image with optional diagnostics.
+
+        Parameters
+        ----------
+        image_name : str
+            Name of the image that was not found.
+        matches : int, optional
+            Number of matches detected above the confidence threshold.
+        best_score : float, optional
+            Highest score returned by the matching algorithm.
+        confidence : float, optional
+            Confidence threshold used for the search.
+        """
+
         self.image_name = image_name
+        self.matches = matches
+        self.best_score = best_score
+        self.confidence = confidence
 
     def __str__(self):
-        return 'Reference image "%s" was not found on screen' % self.image_name
+        msg = 'Reference image "%s" was not found on screen' % self.image_name
+        details = []
+        if self.matches is not None:
+            details.append(f"matches found: {self.matches}")
+        if self.best_score is not None and self.confidence is not None:
+            details.append(
+                f"best score {self.best_score:.2f} (confidence {self.confidence:.2f})"
+            )
+        elif self.best_score is not None:
+            details.append(f"best score {self.best_score:.2f}")
+        elif self.confidence is not None:
+            details.append(f"confidence {self.confidence:.2f}")
+        if details:
+            msg += ". " + ", ".join(details)
+        return msg
 
 
 class InvalidImageException(Exception):


### PR DESCRIPTION
## Summary
- include match count, best score, and confidence in ImageNotFoundException
- log extra details when locate fails and propagate errors in wait_for

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b141c0f483339b5cb4c0c356e2d4