### PR TITLE
Handle missing match counts in ImageNotFoundException

### DIFF
--- a/src/ImageHorizonLibrary/errors.py
+++ b/src/ImageHorizonLibrary/errors.py
@@ -7,7 +7,7 @@ class ImageNotFoundException(Exception):
     def __init__(
         self,
         image_name,
-        matches=0,
+        matches=None,
         best_score=None,
         confidence=None,
     ):
@@ -18,7 +18,8 @@ class ImageNotFoundException(Exception):
         image_name : str
             Name of the image that was not found.
         matches : int, optional
-            Number of matches detected above the confidence threshold.
+            Number of matches detected above the confidence threshold. Defaults
+            to ``None``.
         best_score : float, optional
             Highest score returned by the matching algorithm.
         confidence : float, optional
@@ -33,7 +34,7 @@ class ImageNotFoundException(Exception):
     def __str__(self):
         msg = 'Reference image "%s" was not found on screen' % self.image_name
         details = []
-        if self.matches is not None:
+        if self.matches:
             details.append(f"matches found: {self.matches}")
         if self.best_score is not None and self.confidence is not None:
             details.append(

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -428,7 +428,6 @@ class _RecognizeImages(object):
             self._run_on_failure()
             raise ImageNotFoundException(
                 reference_image,
-                matches=matches,
                 best_score=best_score,
                 confidence=confidence,
             )


### PR DESCRIPTION
## Summary
- make `ImageNotFoundException.matches` optional
- only include match count in message when matches exist
- stop passing 0 matches from image recognition

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b6e9f7e483339d01d4fac365fadd