### PR TITLE
Handle missing match counts in ImageNotFoundException

### DIFF
--- a/src/ImageHorizonLibrary/errors.py
+++ b/src/ImageHorizonLibrary/errors.py
@@ -7,7 +7,7 @@ class ImageNotFoundException(Exception):
     def __init__(
         self,
         image_name,
-        matches=0,
+        matches=None,
         best_score=None,
         confidence=None,
     ):
@@ -18,7 +18,8 @@ class ImageNotFoundException(Exception):
         image_name : str
             Name of the image that was not found.
         matches : int, optional
-            Number of matches detected above the confidence threshold.
+            Number of matches detected above the confidence threshold. Defaults
+            to ``None``.
         best_score : float, optional
             Highest score returned by the matching algorithm.
         confidence : float, optional
@@ -33,7 +34,7 @@ class ImageNotFoundException(Exception):
     def __str__(self):
         msg = 'Reference image "%s" was not found on screen' % self.image_name
         details = []
-        if self.matches is not None:
+        if self.matches:
             details.append(f"matches found: {self.matches}")
         if self.best_score is not None and self.confidence is not None:
             details.append(

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -94,8 +94,17 @@ class _RecognizeImages(object):
         tuple
             A tuple ``(x, y, score, scale)`` with the coordinates of the match,
             optional matching score and detected scale factor.
+
+        Raises
+        ------
+        ImageNotFoundException
+            If ``reference_image`` cannot be located within ``timeout``.
         """
-        x, y, score, scale = self.wait_for(reference_image, timeout)
+        try:
+            x, y, score, scale = self.wait_for(reference_image, timeout)
+        except ImageNotFoundException as e:
+            LOGGER.info(e)
+            raise
         LOGGER.info(
             'Clicking image "%s" in position %s' % (reference_image, (x, y))
         )
@@ -126,7 +135,11 @@ class _RecognizeImages(object):
 
         Parameters are the same as in :py:meth:`click_to_the_above_of_image`.
         """
-        x, y, score, scale = self.wait_for(reference_image, timeout)
+        try:
+            x, y, score, scale = self.wait_for(reference_image, timeout)
+        except ImageNotFoundException as e:
+            LOGGER.info(e)
+            raise
         self._click_to_the_direction_of(
             direction, (x, y), offset, clicks, button, interval
         )
@@ -428,7 +441,6 @@ class _RecognizeImages(object):
             self._run_on_failure()
             raise ImageNotFoundException(
                 reference_image,
-                matches=matches,
                 best_score=best_score,
                 confidence=confidence,
             )
@@ -525,7 +537,11 @@ class _RecognizeImages(object):
         ImageNotFoundException
             If the image is not found on screen.
         """
-        return self._locate(reference_image)
+        try:
+            return self._locate(reference_image)
+        except ImageNotFoundException as e:
+            LOGGER.info(e)
+            raise
 
     def locate_all(self, reference_image):
         """Locate all occurrences of an image on screen.

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -50,6 +50,16 @@ class TestRecognizeImages(TestCase):
             self.lib.click_image('my_picture')
             self.mock.click.assert_called_once_with((0, 0))
 
+    def test_click_image_logs_details_on_failure(self):
+        from ImageHorizonLibrary import ImageNotFoundException
+
+        exc = ImageNotFoundException('missing', best_score=0.5, confidence=0.8)
+        with patch.object(self.lib, 'wait_for', side_effect=exc), \
+             patch('ImageHorizonLibrary.recognition._recognize_images.LOGGER') as log:
+            with self.assertRaises(ImageNotFoundException):
+                self.lib.click_image('missing')
+            log.info.assert_any_call(exc)
+
     def _call_all_directional_functions(self, fn_name):
         from ImageHorizonLibrary import ImageHorizonLibrary
         retvals = []
@@ -70,6 +80,16 @@ class TestRecognizeImages(TestCase):
     def test_directional_clicks(self):
         self._call_all_directional_functions('click_to_the_%s_of_image')
         self._verify_calls_to_pyautogui(self.mock.click.mock_calls)
+
+    def test_directional_click_logs_details_on_failure(self):
+        from ImageHorizonLibrary import ImageNotFoundException
+
+        exc = ImageNotFoundException('missing', best_score=0.5, confidence=0.8)
+        with patch.object(self.lib, 'wait_for', side_effect=exc), \
+             patch('ImageHorizonLibrary.recognition._recognize_images.LOGGER') as log:
+            with self.assertRaises(ImageNotFoundException):
+                self.lib.click_to_the_above_of_image('missing', 10)
+            log.info.assert_any_call(exc)
 
     def test_directional_copies(self):
         copy = 'ImageHorizonLibrary.ImageHorizonLibrary.copy'
@@ -198,6 +218,16 @@ class TestRecognizeImages(TestCase):
              patch.object(self.lib, '_run_on_failure', run_on_failure):
             self.lib.locate('nonexistent')
             run_on_failure.assert_called_once_with()
+
+    def test_locate_logs_details_on_failure(self):
+        from ImageHorizonLibrary import ImageNotFoundException
+
+        exc = ImageNotFoundException('missing', best_score=0.5, confidence=0.8)
+        with patch(self._locate, side_effect=exc), \
+             patch('ImageHorizonLibrary.recognition._recognize_images.LOGGER') as log:
+            with self.assertRaises(ImageNotFoundException):
+                self.lib.locate('missing')
+            log.info.assert_any_call(exc)
 
     def test_locate_with_valid_reference_folder(self):
         for ref, img in (('reference_images', 'my_picture.png'),


### PR DESCRIPTION
## Summary
- make `ImageNotFoundException.matches` optional
- only include match count in message when matches exist
- stop passing 0 matches from image recognition
- log diagnostics when image lookup fails in click and locate helpers

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b6e9f7e483339d01d4fac365fadd