### PR TITLE
feat: allow debug image to override reference folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Generated keyword documentation is available in
 | Copy From The Below Of | Copy text below a reference image. |
 | Copy From The Left Of | Copy text left of a reference image. |
 | Copy From The Right Of | Copy text right of a reference image. |
-| Debug Image | Halts the test execution and opens the image debugger UI. |
+| Debug Image | Halts the test execution and opens the image debugger UI; accepts an optional reference folder. |
 | Does Exist | Check whether a reference image exists on the screen. |
 | Double Click | Double-click with the specified mouse button. |
 | Get Clipboard Content | Return the current text from the system clipboard. |

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -152,7 +152,7 @@ class ImageHorizonLibrary(
     - apply the `template_matching` routine to get a [https://en.wikipedia.org/wiki/Cross-correlation|cross correlation] matrix of values from -1 (no correlation) to +1 (perfect correlation).
     - Filter out only those coordinates with values greater than the ``confidence`` level, take the max
 
-    The keyword `Debug Image` opens a debugger UI where confidence level, Gaussian sigma and low/high thresholds can be tested and adjusted to individual needs.
+    The keyword `Debug Image` opens a debugger UI where confidence level, Gaussian sigma and low/high thresholds can be tested and adjusted to individual needs. It also accepts an optional ``reference_folder`` argument to inspect images stored in a different location.
 
     Edge detection costs some extra CPU time; you should always first try
     to use the ``default`` strategy and only selectively switch to ``edge``

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -624,7 +624,7 @@ class _RecognizeImages(object):
         )
         return location
 
-    def debug_image(self):
+    def debug_image(self, reference_folder=None):
         """Halts the test execution and opens the image debugger UI.
 
         Whenever you encounter problems with the recognition accuracy of a reference image,
@@ -646,11 +646,21 @@ class _RecognizeImages(object):
         | Set Strategy  edge  edge_sigma=2.0  edge_low_threshold=0.1  edge_high_threshold=0.3
         | Wait For  hard_to_find_button
 
+        ``reference_folder`` can be given to temporarily override the folder
+        from which reference images are loaded.
+
         The purpose of this keyword is *solely for debugging purposes*; don't
         use it in production!"""
         from .ImageDebugger import ImageDebugger
 
-        debug_app = ImageDebugger(self)
+        previous_reference_folder = self.reference_folder
+        if reference_folder is not None:
+            self.set_reference_folder(reference_folder)
+        try:
+            debug_app = ImageDebugger(self)
+        finally:
+            if reference_folder is not None:
+                self.set_reference_folder(previous_reference_folder)
 
 
 class _StrategyPyautogui:


### PR DESCRIPTION
## Summary
- allow Debug Image keyword to accept optional `reference_folder`
- document reference folder usage for Debug Image keyword

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6c693076c83338761b95246a4d677