### PR TITLE
Ensure debugger window is restored after taking screenshot

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -113,17 +113,18 @@ class UILocatorController:
         restores it after 10 seconds.
         """
         try:
-            self.view.wm_state("iconic")
+            self.view.iconify()
         except Exception as exc:  # pragma: no cover - depends on tk implementation
             raise RuntimeError(f"Failed to minimise debugger window: {exc}") from exc
 
-        restore_id = self.view.after(10000, lambda: self.view.wm_state("normal"))
+        restore_id = self.view.after(10000, self.view.deiconify)
         try:
             return self.model.capture_desktop()
         finally:
             self.view.after_cancel(restore_id)
             try:
-                self.view.wm_state("normal")
+                self.view.deiconify()
+                self.view.lift()
             except Exception as exc:  # pragma: no cover - depends on tk implementation
                 LOGGER.error(f"Restoring debugger window failed: {exc}")
     

--- a/tests/utest/test_image_debugger_controller.py
+++ b/tests/utest/test_image_debugger_controller.py
@@ -20,12 +20,18 @@ class FakeView:
         self.after_called = None
         self.after_cancel_called = None
 
-    def wm_state(self, state):
-        if state == 'iconic' and self.fail_minimise:
+    def iconify(self):
+        if self.fail_minimise:
             raise Exception('minimise failed')
-        if state == 'normal' and self.fail_restore:
+        self.state_calls.append('iconify')
+
+    def deiconify(self):
+        if self.fail_restore:
             raise Exception('restore failed')
-        self.state_calls.append(state)
+        self.state_calls.append('deiconify')
+
+    def lift(self):
+        self.state_calls.append('lift')
 
     def after(self, delay, func):
         self.after_called = (delay, func)
@@ -51,7 +57,7 @@ class TestTakeScreenshot(TestCase):
         result = ctrl._take_screenshot()
 
         self.assertEqual(result, 'img')
-        self.assertEqual(view.state_calls, ['iconic', 'normal'])
+        self.assertEqual(view.state_calls, ['iconify', 'deiconify', 'lift'])
         self.assertEqual(view.after_called[0], 10000)
         self.assertEqual(view.after_cancel_called, 'id')
 
@@ -64,7 +70,7 @@ class TestTakeScreenshot(TestCase):
         with self.assertRaises(RuntimeError):
             ctrl._take_screenshot()
 
-        self.assertEqual(view.state_calls, ['iconic', 'normal'])
+        self.assertEqual(view.state_calls, ['iconify', 'deiconify', 'lift'])
         self.assertEqual(view.after_cancel_called, 'id')
 
     def test_minimise_failure_raises_runtime_error(self):


### PR DESCRIPTION
## Summary
- Fix debug window auto-closing by restoring it with `deiconify()` and `lift()` after screenshots
- Update screenshot controller tests for new window restoration logic

## Testing
- `pytest tests/utest/test_image_debugger_controller.py`
- `pytest` *(fails: AttributeError: module 'cv2.dnn' has no attribute 'DictValue')*


------
https://chatgpt.com/codex/tasks/task_e_68b6cf9ab0588333bcac9f68ebeadd34