### PR TITLE
Restore debugger window state after screenshot

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -112,6 +112,8 @@ class UILocatorController:
         avoid leaving the window hidden in case of failures, a safety timer
         restores it after 10 seconds.
         """
+        previous_state = self.view.state()
+
         try:
             self.view.iconify()
         except Exception as exc:  # pragma: no cover - depends on tk implementation
@@ -124,6 +126,7 @@ class UILocatorController:
             self.view.after_cancel(restore_id)
             try:
                 self.view.deiconify()
+                self.view.state(previous_state)
                 self.view.lift()
             except Exception as exc:  # pragma: no cover - depends on tk implementation
                 LOGGER.error(f"Restoring debugger window failed: {exc}")


### PR DESCRIPTION
## Summary
- Ensure Image Debugger restores its previous window state after taking a screenshot
- Extend FakeView in tests to emulate window state and add coverage for zoomed restore

## Testing
- `python tests/utest/run_tests.py` *(fails: AttributeError: module 'cv2.dnn' has no attribute 'DictValue')*

------
https://chatgpt.com/codex/tasks/task_e_68b6d24ea2a483339f9ead3c35f4b7d2