### PR TITLE
Default debug window minimize set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Generated keyword documentation is available in
 | Copy From The Below Of | Copy text below a reference image. |
 | Copy From The Left Of | Copy text left of a reference image. |
 | Copy From The Right Of | Copy text right of a reference image. |
-| Debug Image | Halts the test execution and opens the image debugger UI; accepts an optional reference folder and a ``minimize`` flag to keep the debugger window visible. |
+| Debug Image | Halts the test execution and opens the image debugger UI; accepts an optional reference folder and a ``minimize`` flag to hide the debugger window during screenshots (defaults to visible). |
 | Does Exist | Check whether a reference image exists on the screen. |
 | Double Click | Double-click with the specified mouse button. |
 | Get Clipboard Content | Return the current text from the system clipboard. |

--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -152,7 +152,7 @@ class ImageHorizonLibrary(
     - apply the `template_matching` routine to get a [https://en.wikipedia.org/wiki/Cross-correlation|cross correlation] matrix of values from -1 (no correlation) to +1 (perfect correlation).
     - Filter out only those coordinates with values greater than the ``confidence`` level, take the max
 
-    The keyword `Debug Image` opens a debugger UI where confidence level, Gaussian sigma and low/high thresholds can be tested and adjusted to individual needs. It also accepts optional ``reference_folder`` and ``minimize`` arguments to inspect images stored in a different location or keep the debugger window visible during screenshots.
+    The keyword `Debug Image` opens a debugger UI where confidence level, Gaussian sigma and low/high thresholds can be tested and adjusted to individual needs. It also accepts optional ``reference_folder`` and ``minimize`` arguments to inspect images stored in a different location or hide the debugger window during screenshots (visible by default).
 
     Edge detection costs some extra CPU time; you should always first try
     to use the ``default`` strategy and only selectively switch to ``edge``

--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/__init__.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/__init__.py
@@ -7,7 +7,7 @@ from .image_debugger_controller import UILocatorController
 class ImageDebugger:
     """Wrapper that launches the image debugger GUI."""
 
-    def __init__(self, image_horizon_instance, minimize=True):
+    def __init__(self, image_horizon_instance, minimize=False):
         """Create the debugger and start the main UI loop."""
         app = UILocatorController(image_horizon_instance, minimize=minimize)
         app.main()

--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -15,7 +15,7 @@ from robot.api import logger as LOGGER
 class UILocatorController:
     """Connects debugger model and view components."""
 
-    def __init__(self, image_horizon_instance, minimize=True):
+    def __init__(self, image_horizon_instance, minimize=False):
         """Create controller and associated model/view objects."""
         self.image_container = ImageContainer()
         self.model = UILocatorModel()

--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -636,7 +636,7 @@ class _RecognizeImages(object):
         )
         return location
 
-    def debug_image(self, reference_folder=None, minimize=True):
+    def debug_image(self, reference_folder=None, minimize=False):
         """Halts the test execution and opens the image debugger UI.
 
         Whenever you encounter problems with the recognition accuracy of a reference image,
@@ -648,7 +648,7 @@ class _RecognizeImages(object):
         The test will halt at this position and open the debugger UI. Use it as follows:
 
         - Select the reference image (`hard_to_find_button`)
-        - Click the button "Detect reference image" for the strategy you want to test (default/edge). The GUI hides itself while it takes the screenshot of the current application unless ``minimize`` is ``False``.
+        - Click the button "Detect reference image" for the strategy you want to test (default/edge). The GUI hides itself while it takes the screenshot of the current application when ``minimize`` is ``True``.
         - The Image Viewer at the botton shows the screenshot with all regions where the reference image was found.
         - "Matches Found": More than one match means that either `conficence` is set too low or that the reference image is visible multiple times. If the latter is the case, you should first detect a unique UI element and use relative keywords like `Click To The Right Of`.
         - "Max peak value" (only `edge`) gives feedback about the detection accuracy of the best match and is measured as a float number between 0 and 1. A peak value above _confidence_ results in a match.
@@ -662,8 +662,9 @@ class _RecognizeImages(object):
         from which reference images are loaded.
 
         ``minimize`` controls whether the debugger window is minimised before
-        taking a screenshot. Set it to ``False`` to keep the window visible; its
-        area will be masked so that matches inside the debugger are ignored.
+        taking a screenshot. By default the window is kept visible; set
+        ``minimize`` to ``True`` to minimise it. When visible, the window's area
+        is masked so that matches inside the debugger are ignored.
 
         The purpose of this keyword is *solely for debugging purposes*; don't
         use it in production!"""


### PR DESCRIPTION
## Summary
- Keep image debugger window visible by default and only minimize when explicitly requested
- Document new default behavior for `Debug Image` keyword

## Testing
- `PYTHONPATH=src pytest tests/utest/test_image_debugger_controller.py -q` *(fails: module 'cv2.dnn' has no attribute 'DictValue')*


------
https://chatgpt.com/codex/tasks/task_e_68b6da63a7cc8333bc3c9af037868e79