### PR TITLE
test: mock cv2 in edge parameter test

### DIFF
--- a/tests/utest/test_locate_keyword_strategies.py
+++ b/tests/utest/test_locate_keyword_strategies.py
@@ -58,7 +58,14 @@ class TestLocateKeywordStrategies(TestCase):
         from unittest.mock import MagicMock, patch
         import numpy as np
 
-        with patch.dict('sys.modules', {'pyautogui': MagicMock()}):
+        fake_cv2 = MagicMock()
+        fake_cv2.threshold.return_value = (127, None)
+        fake_cv2.THRESH_BINARY = 0
+        fake_cv2.THRESH_OTSU = 0
+
+        with patch.dict(
+            "sys.modules", {"pyautogui": MagicMock(), "cv2": fake_cv2}
+        ):
             from ImageHorizonLibrary.recognition._recognize_images import _StrategyCv2
 
             class DummyIH:


### PR DESCRIPTION
## Summary
- avoid AttributeError in _StrategyCv2 tests by mocking cv2

## Testing
- `PYTHONPATH=src pytest tests/utest/test_locate_keyword_strategies.py::TestLocateKeywordStrategies::test_auto_edge_parameters_returns_scalars -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e3f18abc8333acfc3fdbcb204458