### PR TITLE
Fix screenshot masking test to avoid OpenCV dependency

### DIFF
--- a/tests/utest/test_image_debugger_controller.py
+++ b/tests/utest/test_image_debugger_controller.py
@@ -123,10 +123,10 @@ class TestTakeScreenshot(TestCase):
         view = FakeView()
         ctrl = self._get_controller(view=view, model=model)
         ctrl._minimize = False
-        with patch('ImageHorizonLibrary.recognition.ImageDebugger.image_debugger_controller.ImageDraw') as mock_draw:
-            mock_draw.Draw.return_value = MagicMock()
+        with patch('PIL.ImageDraw.Draw') as mock_draw:
+            mock_draw.return_value = MagicMock()
             result = ctrl._take_screenshot()
         self.assertEqual(result, 'img')
         self.assertEqual(view.state_calls, [])
-        mock_draw.Draw.assert_called_once_with('img')
-        mock_draw.Draw.return_value.rectangle.assert_called_once()
+        mock_draw.assert_called_once_with('img')
+        mock_draw.return_value.rectangle.assert_called_once()


### PR DESCRIPTION
## Summary
- mock `PIL.ImageDraw.Draw` in `test_capture_without_minimise_masks_window` to prevent OpenCV from loading

## Testing
- `PYTHONPATH=src pytest tests/utest/test_image_debugger_controller.py::TestTakeScreenshot::test_capture_without_minimise_masks_window -q`

------
https://chatgpt.com/codex/tasks/task_e_68b6e3ad76e48333bcbc2f30d67109c2