### PR TITLE
Display best match score in debugger results

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/template_matching_strategies.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/template_matching_strategies.py
@@ -39,8 +39,13 @@ class Pyautogui(TemplateMatchingStrategy):
                 self.image_container.get_haystack_image_orig_size(ImageFormat.PILIMG),
             )
         )
-        # Each match is ``(location, score, scale)``; keep only location.
+        # Each match is ``(location, score, scale)``; keep only location and
+        # determine the best score among all matches.
         self.coord = [loc for loc, _, _ in matches]
+        self.best_score = max(
+            (score for _, score, _ in matches if score is not None),
+            default=None,
+        )
         return self.coord
 
 
@@ -60,6 +65,11 @@ class Cv2(TemplateMatchingStrategy):
                 self.image_container.get_haystack_image_orig_size(ImageFormat.NUMPYARRAY),
             )
         )
-        # Keep only location information for highlighting/plotting.
+        # Keep only location information for highlighting/plotting and store
+        # the best score for later display.
         self.coord = [loc for loc, _, _ in matches]
+        self.best_score = max(
+            (score for _, score, _ in matches if score is not None),
+            default=None,
+        )
         return self.coord


### PR DESCRIPTION
## Summary
- track best score across template matching strategies
- show best score next to match count in debugger results and plots

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b846b9c32c8333a61b4ed3b1186bcf