### PR TITLE
Display best match score in debugger results

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_controller.py
@@ -7,7 +7,6 @@ from .image_manipulation import ImageContainer, ImageFormat
 from pathlib import Path
 import os, glob
 import pyperclip
-import numpy as np
 import webbrowser
 from robot.api import logger as LOGGER
 
@@ -22,6 +21,7 @@ class UILocatorController:
         self.image_horizon_instance = image_horizon_instance
         self._minimize = minimize
         self.view = UILocatorView(self, self.image_container, self.image_horizon_instance)
+        self.best_score = None
 
     def main(self):
         """Run the main UI loop."""
@@ -43,6 +43,7 @@ class UILocatorController:
         self.view.btn_copy_strategy_snippet["state"] = "disabled"
         self.view.hint_msg.set("Ready")
         self.view.processing_done = False
+        self.best_score = None
 
     def help(self):
         """Open online keyword documentation."""
@@ -77,6 +78,7 @@ class UILocatorController:
         self.view.matches_found.set("None")
         self.view.label_matches_found.config(fg='black')
         self.view.set_strategy_snippet.set("")
+        self.best_score = None
     
     def refresh(self):
         """Reload available images and reset the UI state."""
@@ -161,6 +163,7 @@ class UILocatorController:
 
             matcher = Pyautogui(self.image_container, self.image_horizon_instance)
             self.coord = matcher.find_num_of_matches()
+            self.best_score = matcher.best_score
             matcher.highlight_matches()
 
             self.haystack_image = self.image_container.get_haystack_image(
@@ -171,7 +174,12 @@ class UILocatorController:
             )
 
             num_of_matches_found = len(self.coord)
-            self.view.matches_found.set(num_of_matches_found)
+            best_score_str = (
+                f"{self.best_score:.2f}" if self.best_score is not None else "N/A"
+            )
+            self.view.matches_found.set(
+                f"{num_of_matches_found} (best score = {best_score_str})"
+            )
             font_color = self.model.change_color_of_label(num_of_matches_found)
             self.view.label_matches_found.config(fg=font_color)
 
@@ -217,6 +225,7 @@ class UILocatorController:
 
             matcher = Cv2(self.image_container, self.image_horizon_instance)
             self.coord = matcher.find_num_of_matches()
+            self.best_score = matcher.best_score
             matcher.highlight_matches()
 
             self.haystack_image = self.image_container.get_haystack_image(
@@ -227,13 +236,12 @@ class UILocatorController:
             )
 
             num_of_matches_found = len(self.coord)
-            max_peak = round(np.amax(self.image_horizon_instance.peakmap), 2)
-            if max_peak < 0.75:
-                result_msg = f"{num_of_matches_found} / max peak value below 0.75"
-            else:
-                result_msg = f"{num_of_matches_found} / {max_peak}"
-
-            self.view.matches_found.set(result_msg)
+            best_score_str = (
+                f"{self.best_score:.2f}" if self.best_score is not None else "N/A"
+            )
+            self.view.matches_found.set(
+                f"{num_of_matches_found} (best score = {best_score_str})"
+            )
             font_color = self.model.change_color_of_label(num_of_matches_found)
             self.view.label_matches_found.config(fg=font_color)
             self.view.btn_edge_detec_debugger["state"] = "normal"
@@ -259,8 +267,11 @@ class UILocatorController:
 
     def on_click_plot_results_edge(self):
         """Display detailed edge detection results in a matplotlib window."""
+        best_score_str = (
+            f"{self.best_score:.2f}" if self.best_score is not None else "N/A"
+        )
         title = (
-            f"{self.view.matches_found.get()} matches (confidence: "
+            f"{len(self.coord)} matches (best score = {best_score_str}, confidence: "
             f"{self.image_horizon_instance.confidence})"
         )
         try:

--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/template_matching_strategies.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/template_matching_strategies.py
@@ -39,8 +39,13 @@ class Pyautogui(TemplateMatchingStrategy):
                 self.image_container.get_haystack_image_orig_size(ImageFormat.PILIMG),
             )
         )
-        # Each match is ``(location, score, scale)``; keep only location.
+        # Each match is ``(location, score, scale)``; keep only location and
+        # determine the best score among all matches.
         self.coord = [loc for loc, _, _ in matches]
+        self.best_score = max(
+            (score for _, score, _ in matches if score is not None),
+            default=None,
+        )
         return self.coord
 
 
@@ -60,6 +65,11 @@ class Cv2(TemplateMatchingStrategy):
                 self.image_container.get_haystack_image_orig_size(ImageFormat.NUMPYARRAY),
             )
         )
-        # Keep only location information for highlighting/plotting.
+        # Keep only location information for highlighting/plotting and store
+        # the best score for later display.
         self.coord = [loc for loc, _, _ in matches]
+        self.best_score = max(
+            (score for _, score, _ in matches if score is not None),
+            default=None,
+        )
         return self.coord


### PR DESCRIPTION
## Summary
- track best score across template matching strategies
- show best score next to match count in debugger results and plots
- drop redundant max peak output for edge detection results

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b846b9c32c8333a61b4ed3b1186bcf