### PR TITLE
Add Docker build scripts for wheel creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM --platform=linux/amd64 python:3.11-slim AS build
+
+WORKDIR /work
+
+# Create virtual environment
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Build wheel without dependencies
+RUN pip wheel --no-deps -w dist .

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM --platform=linux/arm64 python:3.11-slim AS build
+
+WORKDIR /work
+
+# Create virtual environment
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Build wheel without dependencies
+RUN pip wheel --no-deps -w dist .

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Documentation has been adapted for GitHub Pages and is available at [https://3x3
   - [macOS](#macos)
   - [Linux](#linux)
 - [Building from source](#building-from-source)
+- [Building with Docker](#building-with-docker)
 - [Running unit tests](#running-unit-tests)
 - [Running acceptance tests](#running-acceptance-tests)
 - [Updating docs](#updating-docs)
@@ -253,6 +254,28 @@ Then build the wheel:
 ```
 pip wheel . --no-deps
 ```
+## Building with Docker
+
+Dockerfiles are provided to build wheels in isolated environments.
+
+### x86_64
+
+```bash
+docker build -t imagehorizonlib-wheel .
+CID=$(docker create imagehorizonlib-wheel)
+docker cp $CID:/work/dist ./dist
+docker rm $CID
+```
+
+### arm64
+
+```bash
+docker build -f Dockerfile.arm64 -t imagehorizonlib-wheel:arm64 .
+CID=$(docker create imagehorizonlib-wheel:arm64)
+docker cp $CID:/work/dist ./dist
+docker rm $CID
+```
+
 
 ## Running unit tests
 


### PR DESCRIPTION
## Summary
- add Dockerfile that builds a wheel inside a venv for x86_64
- provide Dockerfile.arm64 to support arm64 builds
- document Docker build instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c10d6cb5bc83338e1c0d27860200fc