### PR TITLE
ci: build wheel on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Build and attach wheel
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tool
+        run: pip install build
+      - name: Build wheel
+        run: python -m build --wheel
+      - name: Upload wheel to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.whl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- build wheel and attach it to every published release

## Testing
- `python3 tests/utest/run_tests.py` *(fails: ImportError: libGL.so.1 missing)*
- `python3 tests/atest/run_tests.py` *(fails: KeyError: 'DISPLAY')*

------
https://chatgpt.com/codex/tasks/task_e_68c110aebbb88333bd3f60fa7b43338a