### PR TITLE
Add sys.path setup for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on sys.path for tests
+ROOT = Path(__file__).resolve().parent
+SRC = ROOT / 'src'
+if SRC.exists() and str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))


### PR DESCRIPTION
## Summary
- ensure tests can import the library by adding `src` to `sys.path`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1148fb7d48333aa47e8c827a49865