### PR TITLE
chore: update workflow actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,10 @@ jobs:
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
 
       - name: Setup python ${{ matrix.python-version }} for running the tests
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           architecture: 'x64'
@@ -70,7 +70,7 @@ jobs:
           python tests/atest/run_tests.py
 
       - name: Archive acceptances test results
-        uses: actions/upload-artifact@v2.3.0
+        uses: actions/upload-artifact@v4
         with:
           name: output-${{ matrix.python-version }}-${{ matrix.os }}
           path: |


### PR DESCRIPTION
## Summary
- update tests workflow to supported actions

## Testing
- `python tests/utest/run_tests.py` *(fails: AttributeError: module 'cv2.dnn' has no attribute 'DictValue')*
- `python tests/atest/run_tests.py` *(fails: Exception: To take screenshots, you must install Pillow version 9.2.0 or greater and gnome-screenshot)*

------
https://chatgpt.com/codex/tasks/task_e_68c19bb2e9688333b55621402493e030