### PR TITLE
replace pytest skip with unittest SkipTest

### DIFF
--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 import time
 
-from unittest import TestCase, skip
+from unittest import TestCase, SkipTest
 from os.path import abspath, dirname, join as path_join
 from unittest.mock import call, MagicMock, patch, ANY
 
-import pytest
 try:  # pragma: no cover - optional dependency
     import cv2
 except Exception:  # pragma: no cover - skip tests if OpenCV is missing/broken
     cv2 = None
-    pytest.skip("OpenCV is not available", allow_module_level=True)
+    raise SkipTest("OpenCV is not available")
 
 import numpy as np
 


### PR DESCRIPTION
## Summary
- remove pytest import from tests and use unittest.SkipTest when OpenCV is unavailable

## Testing
- `python tests/utest/run_tests.py`
- ⚠️ `python tests/atest/run_tests.py` (fails: DisplayConnectionError: Can't connect to display ":99": [Errno 2] No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68c1a344e65883338b0418b0afed6d70