### PR TITLE
Run tests headless with Xvfb

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,13 +21,6 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest' ]
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
-        include:
-          - os: ubuntu-latest
-            set_display: export DISPLAY=:99; Xvfb :99 -screen 0 1024x768x24 -ac -noreset & sleep 3
-          #- os: macos-latest
-            #set_tmpdir: export TMPDIR=/tmp
-          - os: windows-latest
-            set_codepage: chcp 850
 
     runs-on: ${{ matrix.os }}
 
@@ -53,19 +46,28 @@ jobs:
       - name: Install test tools to Linux
         run: |
           sudo apt-get update
-          sudo apt-get -y -q install xvfb scrot
+          sudo apt-get -y -q install xvfb scrot gnome-screenshot
           touch ~/.Xauthority
-        if: contains(matrix.os, 'ubuntu')
+        if: runner.os == 'Linux'
 
       - name: Install python test dependencies
         run: |
           python --version
           python -m pip install mock robotframework opencv-python eel .
 
-      - name: Run tests
+      - name: Run tests on Linux
+        if: runner.os == 'Linux'
         run: |
-          ${{ matrix.set_codepage }}
-          ${{ matrix.set_display }}
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1024x768x24 -ac -noreset & sleep 3
+          python tests/utest/run_tests.py
+          python tests/atest/run_tests.py
+
+      - name: Run tests on Windows
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          chcp 850
           python tests/utest/run_tests.py
           python tests/atest/run_tests.py
 


### PR DESCRIPTION
## Summary
- launch Xvfb for Linux test runs and install gnome-screenshot
- split test execution between Linux and Windows in CI

## Testing
- `python tests/utest/run_tests.py`
- `python tests/atest/run_tests.py` *(fails: ImageNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a87a91dc83338c5b11180145ae96