### PR TITLE
Silence numpy reload warning

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -7,6 +7,11 @@ from contextlib import contextmanager
 import pyautogui as ag
 from robot.api import logger as LOGGER
 
+# ``cv2`` imports ``numpy`` internally.  Import ``numpy`` explicitly first to
+# ensure it is loaded only once and avoid "module reloaded" warnings on Python
+# 3.12+.
+import numpy as np
+
 try:  # pragma: no cover - optional dependency
     import cv2
     # ``DictValue`` vanished from some OpenCV builds.  Tests exercising the
@@ -33,7 +38,6 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - graceful fallback when cv2 is missing
     cv2 = None
 
-import numpy as np
 import traceback
 
 

--- a/tests/utest/run_tests.py
+++ b/tests/utest/run_tests.py
@@ -4,6 +4,14 @@ import sys
 
 from os.path import abspath, dirname, join as path_join
 from unittest import TestLoader, TextTestRunner
+import warnings
+
+# Suppress spurious warnings from OpenCV reimporting NumPy during test discovery
+warnings.filterwarnings(
+    "ignore",
+    message="The NumPy module was reloaded",
+    category=UserWarning,
+)
 
 directory = dirname(__file__)
 path = path_join(abspath(path_join(directory, '..', '..', 'src')))

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -8,13 +8,15 @@ import shutil
 import tempfile
 from pathlib import Path
 
+# Import ``numpy`` before ``cv2`` to avoid "module reloaded" warnings when OpenCV
+# pulls it in internally during import.
+import numpy as np
+
 try:  # pragma: no cover - optional dependency
     import cv2
 except Exception:  # pragma: no cover - skip tests if OpenCV is missing/broken
     cv2 = None
     raise SkipTest("OpenCV is not available")
-
-import numpy as np
 
 CURDIR = abspath(dirname(__file__))
 TESTIMG_DIR = path_join(CURDIR, 'reference_images')


### PR DESCRIPTION
## Summary
- avoid NumPy reload warning by importing numpy before cv2
- suppress spurious NumPy reload warning during tests

## Testing
- `python3 tests/utest/run_tests.py verbosity=2`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2d50b8083339b31194e188f4501