### PR TITLE
Fix extension mismatch test in normalization warning

### DIFF
--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -403,7 +403,7 @@ class TestLocateStandalone(TestCase):
 
                 with patch.object(ImageHorizonLibrary, '_locate', _dummy_locate):
                     lib = ImageHorizonLibrary(reference_folder=tmp_dir)
-                    for name in ('MY_PICTURE', 'My_Picture.PNG'):
+                    for name in ('MY_PICTURE', 'My_Picture.png'):
                         with patch('ImageHorizonLibrary.recognition._recognize_images.LOGGER') as log:
                             lib.locate(name)
                             log.warn.assert_called_once()


### PR DESCRIPTION
## Summary
- fix case-mismatch warning test by using lowercase extension to trigger warning

## Testing
- `python -m pytest tests/utest/test_recognize_images.py::TestLocateStandalone::test_locate_warns_about_case_mismatch -vv`
- `python -m pytest tests/utest/test_recognize_images.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2f771b08333a82398493344dfe5