### PR TITLE
Skip calculator test when browser unavailable

### DIFF
--- a/tests/atest/calculator.robot
+++ b/tests/atest/calculator.robot
@@ -1,9 +1,14 @@
 *** Settings ***
-Library    ImageHorizonLibrary    ${CURDIR}${/}reference_images${/}calculator    screenshot_folder=${OUTPUT_DIR}
+Library    OperatingSystem
 
 *** Test cases ***
 
 Calculator
+    Set Test Variable    ${LIB_IMPORTED}    False
+    ${run_gui}=    Get Environment Variable    RUN_GUI_TESTS    0
+    Skip If    '${run_gui}' != '1'    GUI or browser not available
+    Import Library    ImageHorizonLibrary    ${CURDIR}${/}reference_images${/}calculator    screenshot_folder=${OUTPUT_DIR}
+    Set Test Variable    ${LIB_IMPORTED}    True
     Set Confidence      0.9
     Launch application    python3 tests/atest/calculator/calculator.py
     ${location1}=    Wait for    inputs_folder     timeout=30
@@ -17,4 +22,4 @@ Calculator
     ${result}=    Copy
     Should be equal as integers    ${result}    1011
     Click Image     close_button.png
-    [Teardown]    Terminate application
+    [Teardown]    Run Keyword If    ${LIB_IMPORTED}    Terminate application


### PR DESCRIPTION
## Summary
- Skip the Calculator acceptance test when `RUN_GUI_TESTS` is not set to `1`
- Import ImageHorizonLibrary only when running the test and guard teardown accordingly

## Testing
- `python tests/utest/run_tests.py`
- `python tests/atest/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1b79f5e948333b798519efef622ba