### PR TITLE
Handle extra data in click locations

### DIFF
--- a/src/ImageHorizonLibrary/__init__.py
+++ b/src/ImageHorizonLibrary/__init__.py
@@ -371,7 +371,7 @@ class ImageHorizonLibrary(
         self._try_locate = self.strategy_instance._try_locate
 
     def _get_location(self, direction, location, offset):
-        x, y = location
+        x, y = location[:2]
         offset = int(offset)
         if direction == "left":
             x = x - offset

--- a/src/ImageHorizonLibrary/interaction/_mouse.py
+++ b/src/ImageHorizonLibrary/interaction/_mouse.py
@@ -17,7 +17,9 @@ class _Mouse(object):
         direction : str
             One of ``'up'``, ``'down'``, ``'left'`` or ``'right'``.
         location : sequence
-            Two-item sequence ``(x, y)`` representing a screen coordinate.
+            Sequence ``(x, y[, score, scale])`` representing a screen
+            coordinate. Additional values such as match score or scale are
+            ignored.
         offset : int
             Distance in pixels from ``location`` towards ``direction``.
         clicks : int
@@ -40,7 +42,8 @@ class _Mouse(object):
         Parameters
         ----------
         location : sequence
-            Two-item sequence ``(x, y)`` describing a screen coordinate.
+            Sequence ``(x, y[, score, scale])`` describing a screen
+            coordinate. Extra values like match score or scale are ignored.
         offset : int
             Number of pixels the click is moved upwards from ``location``.
         clicks : int, optional


### PR DESCRIPTION
## Summary
- Use only the first two entries of locations to ignore score/scale extras
- Document click helper keywords to accept `(x, y[, score, scale])`

## Testing
- `python tests/utest/run_tests.py`
- `python tests/atest/run_tests.py` *(fails: GUI or browser not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be9b47fc83339a8138d29083d7fa