### PR TITLE
Handle PyAutoGUI ImageNotFoundException

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -836,7 +836,7 @@ class _StrategyPyautogui:
                             "or a confidence level was not given."
                         )
                     location_res = locate_func(ref_image, haystack_image)
-            except ImageNotFoundException as ex:
+            except (ImageNotFoundException, ag.ImageNotFoundException) as ex:
                 LOGGER.info(ex)
                 location_res = None
 

--- a/tests/utest/test_pyautogui_image_not_found.py
+++ b/tests/utest/test_pyautogui_image_not_found.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock, patch
+from PIL import Image
+
+
+def test_strategy_pyautogui_handles_pyautogui_image_not_found():
+    class DummyIH:
+        confidence = None
+        has_cv = False
+        scale_enabled = False
+
+        def _suppress_keyword_on_failure(self):
+            from contextlib import contextmanager
+
+            @contextmanager
+            def dummy():
+                yield
+
+            return dummy()
+
+    dummy_ih = DummyIH()
+    haystack = Image.new("RGB", (10, 10))
+
+    mock_ag = MagicMock()
+
+    class DummyImageNotFoundException(Exception):
+        pass
+
+    mock_ag.ImageNotFoundException = DummyImageNotFoundException
+    mock_ag.locate.side_effect = DummyImageNotFoundException("missing")
+
+    with patch.dict("sys.modules", {"pyautogui": mock_ag}):
+        from ImageHorizonLibrary.recognition import _recognize_images as ri
+        strat = ri._StrategyPyautogui(dummy_ih)
+        location, score, scale = strat._try_locate("dummy", haystack_image=haystack)
+
+    assert location is None
+    assert score is None
+    assert scale == 1.0


### PR DESCRIPTION
## Summary
- handle PyAutoGUI's ImageNotFoundException in _StrategyPyautogui
- add regression test for PyAutoGUI ImageNotFoundException handling

## Testing
- `pytest tests/utest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d9e5eca88333ae6cb55c15052515