### PR TITLE
Use debugpy in VSCode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
   "configurations": [
     {
       "name": "Python: Aktuelle Datei",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${file}",
       "console": "integratedTerminal",
@@ -15,7 +15,7 @@
     },
     {
       "name": "libdoc",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "module": "robot.libdoc",
       "args": [


### PR DESCRIPTION
## Summary
- switch VS Code launch configuration to debugpy to avoid deprecation warnings

## Testing
- `python -m json.tool .vscode/launch.json` *(fails: Expecting property name enclosed in double quotes)*
- `pytest tests/utest`

------
https://chatgpt.com/codex/tasks/task_e_68c51cea612c833396e8c457b3fb69d0