### PR TITLE
Align Browse button with Refresh in image debugger

### DIFF
--- a/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_view.py
+++ b/src/ImageHorizonLibrary/recognition/ImageDebugger/image_debugger_view.py
@@ -59,10 +59,14 @@ class UILocatorView(Tk):
         self.ref_dir_path = StringVar(frame_import_ref_image)
 
         frame_ref_dir = Frame(frame_import_ref_image)
-        frame_ref_dir.pack(side=TOP, anchor=W)
+        frame_ref_dir.pack(side=TOP, fill=X)
         self.label_ref_dir_path = Label(frame_ref_dir, textvariable=self.ref_dir_path, fg='green')
         self.label_ref_dir_path.pack(side=LEFT, anchor=W)
-        Button(frame_ref_dir, text='Browse', command=self.controller.change_reference_folder).pack(side=LEFT, padx=(5, 0))
+        Button(
+            frame_ref_dir,
+            text='Browse',
+            command=self.controller.change_reference_folder,
+        ).pack(side=RIGHT, padx=(5, 0), anchor=E)
 
         self.combobox_needle_img_name = ttk.Combobox(frame_import_ref_image, width=70, state="readonly")
         self.controller.load_needle_image_names(self.combobox_needle_img_name)


### PR DESCRIPTION
## Summary
- Align Browse button to the right in image debugger so it lines up with Refresh

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5217381f083339d04526a2c8f2eee