### PR TITLE
Propagate strategy and screenshot folder errors in wait_for

### DIFF
--- a/src/ImageHorizonLibrary/recognition/_recognize_images.py
+++ b/src/ImageHorizonLibrary/recognition/_recognize_images.py
@@ -41,8 +41,13 @@ except Exception:  # pragma: no cover - graceful fallback when cv2 is missing
 import traceback
 
 
-from ..errors import ImageNotFoundException, InvalidImageException
-from ..errors import ReferenceFolderException
+from ..errors import (
+    ImageNotFoundException,
+    InvalidImageException,
+    ReferenceFolderException,
+    ScreenshotFolderException,
+    StrategyException,
+)
 
 
 class _RecognizeImages(object):
@@ -649,7 +654,12 @@ class _RecognizeImages(object):
                 try:
                     location = self._locate(reference_image, log_it=True)
                     break
-                except (InvalidImageException, ReferenceFolderException):
+                except (
+                    InvalidImageException,
+                    ReferenceFolderException,
+                    StrategyException,
+                    ScreenshotFolderException,
+                ):
                     # These indicate a permanent misconfiguration and should not
                     # be retried within this loop.
                     raise

--- a/tests/utest/test_recognize_images.py
+++ b/tests/utest/test_recognize_images.py
@@ -241,6 +241,28 @@ class TestRecognizeImages(TestCase):
             self.assertEqual(result, (0, 0, 1.0, 1.0))
             self.assertEqual(len(run_on_failure.mock_calls), 0)
 
+    def test_wait_for_propagates_strategy_exception(self):
+        from ImageHorizonLibrary import StrategyException
+
+        run_on_failure = MagicMock()
+        with patch(self._locate, side_effect=StrategyException('fail')) as locate, \
+             patch.object(self.lib, '_run_on_failure', run_on_failure):
+            with self.assertRaises(StrategyException):
+                self.lib.wait_for('my_picture', timeout=1)
+            self.assertEqual(locate.call_count, 1)
+            self.assertEqual(run_on_failure.call_count, 0)
+
+    def test_wait_for_propagates_screenshot_folder_exception(self):
+        from ImageHorizonLibrary import ScreenshotFolderException
+
+        run_on_failure = MagicMock()
+        with patch(self._locate, side_effect=ScreenshotFolderException('fail')) as locate, \
+             patch.object(self.lib, '_run_on_failure', run_on_failure):
+            with self.assertRaises(ScreenshotFolderException):
+                self.lib.wait_for('my_picture', timeout=1)
+            self.assertEqual(locate.call_count, 1)
+            self.assertEqual(run_on_failure.call_count, 0)
+
     def test_set_keyword_on_failure_runs_custom_keyword(self):
         with patch('ImageHorizonLibrary.BuiltIn.run_keyword') as run_keyword:
             self.lib.set_keyword_on_failure('Log')


### PR DESCRIPTION
## Summary
- propagate `StrategyException` and `ScreenshotFolderException` without retry in `wait_for`
- add tests for strategy and screenshot folder error propagation

## Testing
- `pytest tests/utest/test_recognize_images.py::TestRecognizeImages::test_wait_for_propagates_strategy_exception tests/utest/test_recognize_images.py::TestRecognizeImages::test_wait_for_propagates_screenshot_folder_exception -q`
- `pytest tests/utest/test_recognize_images.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c53673ae5c833396a850db0ae19c24