### PR TITLE
ci: add docs build workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,30 @@
+name: Build docs
+
+on:
+  workflow_dispatch:   # manueller Start
+  # push:
+  #   branches: [ main ]   # optional für automatische Ausführung nach Merges
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Abhängigkeiten installieren
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install robotframework
+      - name: Dokumentation generieren
+        run: |
+          python -m robot.libdoc -P ./src ImageHorizonLibrary docs/ImageHorizonLibrary.html
+          cp docs/ImageHorizonLibrary.html docs/index.html
+      - name: Änderungen committen
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/ImageHorizonLibrary.html docs/index.html
+          git commit -m "docs: regenerate" || echo "Keine Änderungen"
+          git push


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to regenerate documentation and commit results

## Testing
- `python tests/utest/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7ac0fe92c8333aacf32235c6190ef