### PR TITLE
ci: install library dependencies for docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install robotframework
-          python -m pip install -r requirements.txt  # ensures pyautogui, Pillow, etc.
+          python -m pip install -r requirements.txt
       - name: Dokumentation generieren
         run: |
           python -m robot.libdoc -P ./src ImageHorizonLibrary docs/ImageHorizonLibrary.html

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install robotframework
+          python -m pip install -r requirements.txt  # ensures pyautogui, Pillow, etc.
       - name: Dokumentation generieren
         run: |
           python -m robot.libdoc -P ./src ImageHorizonLibrary docs/ImageHorizonLibrary.html


### PR DESCRIPTION
## Summary
- ensure documentation workflow installs package dependencies for libdoc generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7b0535a3c8333a4c7e42f41d20b2c