### PR TITLE
Add PyAutoGUI-based dragging, scrolling, and global settings keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ Generated keyword documentation is available in
 | Mouse Down                  | Press and hold a mouse button.                                                                                                                                                             |
 | Mouse Up                    | Release a previously pressed mouse button.                                                                                                                                                 |
 | Move To                     | Move the mouse pointer to absolute screen coordinates.                                                                                                                                     |
+| Move Rel                    | Move the mouse pointer relative to its current position.                                                                                           |
+| Drag To                     | Drag the mouse pointer to absolute screen coordinates while optionally holding a button.                                                           |
+| Drag Rel                    | Drag the mouse pointer relative to its current position.                                                                                           |
+| Scroll                      | Scroll vertically by a number of clicks.                                                                                                           |
+| Scroll Horizontally         | Scroll horizontally by a number of clicks.                                                                                                         |
+| Scroll Vertically           | Scroll vertically by a number of clicks.                                                                                                           |
+| Set Global Pause            | Set the global PyAutoGUI pause between actions.                                                                                                    |
+| Set Failsafe                | Enable or disable the PyAutoGUI failsafe corner detection.                                                                                        |
 | Pause                       | Display a modal dialog to temporarily halt test execution.                                                                                                                                 |
 | Press Combination           | Press multiple keyboard keys simultaneously.                                                                                                                                               |
 | Reset Confidence            | Resets the confidence level to the library default.                                                                                                                                        |

--- a/src/ImageHorizonLibrary/interaction/_mouse.py
+++ b/src/ImageHorizonLibrary/interaction/_mouse.py
@@ -8,6 +8,63 @@ from ..errors import MouseException
 class _Mouse(object):
     """Mixin implementing mouse related actions."""
 
+    def _normalize_point(self, x_value, y_value):
+        """Return a tuple of integers from separate values or a sequence."""
+
+        if y_value is None:
+            if isinstance(x_value, (list, tuple)):
+                if len(x_value) < 2:
+                    raise MouseException(
+                        "Invalid number of coordinates. Please give either (x, y) or x, y."
+                    )
+                x_value, y_value = x_value[:2]
+            else:
+                raise MouseException(
+                    "Invalid number of coordinates. Please give either (x, y) or x, y."
+                )
+        try:
+            return int(x_value), int(y_value)
+        except (TypeError, ValueError):
+            raise MouseException(
+                "Coordinates %s are not integers" % ((x_value, y_value),)
+            )
+
+    def _normalize_offsets(self, x_value, y_value):
+        """Return relative offsets as integers from values or sequences."""
+
+        if y_value is None:
+            if isinstance(x_value, (list, tuple)):
+                if len(x_value) < 2:
+                    raise MouseException(
+                        "Invalid number of offsets. Please give either (x, y) or x, y."
+                    )
+                x_value, y_value = x_value[:2]
+            else:
+                raise MouseException(
+                    "Invalid number of offsets. Please give either (x, y) or x, y."
+                )
+        try:
+            return int(x_value), int(y_value)
+        except (TypeError, ValueError):
+            raise MouseException(
+                "Offsets %s are not integers" % ((x_value, y_value),)
+            )
+
+    def _to_boolean(self, value, argument_name):
+        """Convert Robot Framework truthy/falsey values to bool."""
+
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(int(value))
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in ("true", "1", "yes", "on"):
+                return True
+            if normalized in ("false", "0", "no", "off"):
+                return False
+        raise MouseException('Invalid argument "%s" for `%s`' % (value, argument_name))
+
     def _click_to_the_direction_of(self, direction, location, offset,
                                    clicks, button, interval):
         """Click relative to a location in a given direction.
@@ -136,6 +193,40 @@ class _Mouse(object):
                                  (coordinates,))
         ag.moveTo(*coordinates)
 
+    def move_rel(self, x_offset, y_offset=None, duration=0.0):
+        """Move the mouse pointer relative to its current position.
+
+        Parameters
+        ----------
+        x_offset : int or sequence
+            Horizontal distance to move. Positive values move right, negative
+            values move left. Can also be a two-item sequence ``(x, y)``
+            containing both offsets.
+        y_offset : int, optional
+            Vertical distance to move. Positive values move down, negative
+            values move up. Ignored when ``x_offset`` is a sequence.
+        duration : float, optional
+            Time in seconds for the move. Defaults to ``0.0`` for an instant
+            jump.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        | Move Rel | 50 | -25 |            |
+        | Move Rel | ${offsets} |          | # where ${offsets} is [50, -25]
+        | Move Rel | 10 | 20 | duration=1 |
+        """
+
+        x_offset, y_offset = self._normalize_offsets(x_offset, y_offset)
+        try:
+            duration = float(duration)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `duration`' % duration)
+        ag.moveRel(x_offset, y_offset, duration=duration)
+
     def mouse_down(self, button='left'):
         """Press and hold a mouse button.
 
@@ -211,3 +302,149 @@ class _Mouse(object):
         None
         """
         ag.tripleClick(button=button, interval=float(interval))
+
+    def drag_to(self, x, y=None, duration=0.0, button='left', mouse_down_up=True):
+        """Drag the mouse pointer to absolute screen coordinates.
+
+        Parameters
+        ----------
+        x : int or sequence
+            Target ``x`` coordinate or sequence ``(x, y[, score, scale])``.
+        y : int, optional
+            Target ``y`` coordinate. Ignored when ``x`` is a sequence.
+        duration : float, optional
+            Time in seconds for the drag. Defaults to ``0.0``.
+        button : str, optional
+            Mouse button to use for the drag. Defaults to ``'left'``.
+        mouse_down_up : bool, optional
+            Whether to automatically press and release the button during the
+            drag. Defaults to ``True``.
+
+        Returns
+        -------
+        None
+        """
+
+        x, y = self._normalize_point(x, y)
+        try:
+            duration = float(duration)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `duration`' % duration)
+        mouse_down_up = self._to_boolean(mouse_down_up, 'mouse_down_up')
+        ag.dragTo(x, y, duration=duration, button=button, mouseDownUp=mouse_down_up)
+
+    def drag_rel(self, x_offset, y_offset=None, duration=0.0, button='left',
+                 mouse_down_up=True):
+        """Drag the mouse pointer relative to its current position.
+
+        Parameters
+        ----------
+        x_offset : int or sequence
+            Horizontal offset for the drag. Can be given as ``(x, y[, ...])``
+            sequence containing both offsets.
+        y_offset : int, optional
+            Vertical offset for the drag. Ignored when ``x_offset`` is a
+            sequence.
+        duration : float, optional
+            Time in seconds for the drag. Defaults to ``0.0``.
+        button : str, optional
+            Mouse button to use. Defaults to ``'left'``.
+        mouse_down_up : bool, optional
+            Whether to automatically press and release the button. Defaults to
+            ``True``.
+
+        Returns
+        -------
+        None
+        """
+
+        x_offset, y_offset = self._normalize_offsets(x_offset, y_offset)
+        try:
+            duration = float(duration)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `duration`' % duration)
+        mouse_down_up = self._to_boolean(mouse_down_up, 'mouse_down_up')
+        ag.dragRel(x_offset, y_offset, duration=duration, button=button,
+                   mouseDownUp=mouse_down_up)
+
+    def scroll(self, clicks, x=None, y=None):
+        """Scroll vertically by a number of clicks.
+
+        Parameters
+        ----------
+        clicks : int
+            Number of scroll steps. Positive values scroll up, negative values
+            scroll down.
+        x : int or sequence, optional
+            X coordinate at which to perform the scroll. Accepts ``(x, y[, ...])``
+            sequences. Defaults to the current mouse position when omitted.
+        y : int, optional
+            Y coordinate for the scroll. Ignored when ``x`` is a sequence.
+
+        Returns
+        -------
+        None
+        """
+
+        try:
+            clicks = int(clicks)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `clicks`' % clicks)
+        if x is None and y is None:
+            ag.scroll(clicks)
+        else:
+            x, y = self._normalize_point(x, y)
+            ag.scroll(clicks, x=x, y=y)
+
+    def scroll_horizontally(self, clicks):
+        """Scroll horizontally by a number of clicks.
+
+        Parameters
+        ----------
+        clicks : int
+            Number of scroll steps. Positive values scroll right, negative
+            values scroll left.
+
+        Returns
+        -------
+        None
+        """
+
+        try:
+            clicks = int(clicks)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `clicks`' % clicks)
+        ag.hscroll(clicks)
+
+    def scroll_vertically(self, clicks):
+        """Scroll vertically by a number of clicks.
+
+        Parameters
+        ----------
+        clicks : int
+            Number of scroll steps. Positive values scroll down, negative
+            values scroll up.
+
+        Returns
+        -------
+        None
+        """
+
+        try:
+            clicks = int(clicks)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `clicks`' % clicks)
+        ag.vscroll(clicks)
+
+    def set_global_pause(self, seconds):
+        """Set the global PyAutoGUI pause between actions in seconds."""
+
+        try:
+            ag.PAUSE = float(seconds)
+        except (TypeError, ValueError):
+            raise MouseException('Invalid argument "%s" for `seconds`' % seconds)
+
+    def set_failsafe(self, enabled=True):
+        """Enable or disable the PyAutoGUI failsafe corner detection."""
+
+        ag.FAILSAFE = self._to_boolean(enabled, 'enabled')

--- a/tests/utest/test_mouse.py
+++ b/tests/utest/test_mouse.py
@@ -64,6 +64,30 @@ class TestMouse(TestCase):
                      (('1', 'lollerskates'),)]:
             self._verify_move_to_fails(*args)
 
+    def _verify_move_rel_fails(self, *args, **kwargs):
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.move_rel(*args, **kwargs)
+
+    def test_move_rel(self):
+        for args in [(1, 2), ((1, 2),), ('1', '2'), (('1', '2'),)]:
+            self.lib.move_rel(*args)
+            self.assertEqual(self.mock.moveRel.mock_calls,
+                             [call(1, 2, duration=0.0)])
+            self.mock.reset_mock()
+
+        self.lib.move_rel(1, 2, duration='0.5')
+        self.assertEqual(self.mock.moveRel.mock_calls,
+                         [call(1, 2, duration=0.5)])
+        self.mock.reset_mock()
+
+        for args in [(1,),
+                     ('1', 'nope'),
+                     (('1', 'nope'),)]:
+            self._verify_move_rel_fails(*args)
+
+        self._verify_move_rel_fails(1, 2, duration='not-a-number')
+
     def test_mouse_down(self):
         for args in [tuple(), ('right',)]:
             self.lib.mouse_down(*args)
@@ -73,3 +97,91 @@ class TestMouse(TestCase):
         for args in [tuple(), ('right',)]:
             self.lib.mouse_up(*args)
         self.assertEqual(self.mock.mouseUp.mock_calls, [call(button='left'), call(button='right')])
+
+    def test_drag_to(self):
+        self.lib.drag_to(10, 20)
+        self.assertEqual(
+            self.mock.dragTo.mock_calls,
+            [call(10, 20, duration=0.0, button='left', mouseDownUp=True)]
+        )
+        self.mock.reset_mock()
+
+        self.lib.drag_to((10, 20, 0.8), duration='0.5', button='middle', mouse_down_up='false')
+        self.assertEqual(
+            self.mock.dragTo.mock_calls,
+            [call(10, 20, duration=0.5, button='middle', mouseDownUp=False)]
+        )
+        self.mock.reset_mock()
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.drag_to(10)
+        with self.assertRaises(MouseException):
+            self.lib.drag_to(10, 20, duration='invalid')
+
+    def test_drag_rel(self):
+        self.lib.drag_rel(5, -5)
+        self.assertEqual(
+            self.mock.dragRel.mock_calls,
+            [call(5, -5, duration=0.0, button='left', mouseDownUp=True)]
+        )
+        self.mock.reset_mock()
+
+        self.lib.drag_rel((5, -5, 0.9), duration='1', button='right', mouse_down_up='No')
+        self.assertEqual(
+            self.mock.dragRel.mock_calls,
+            [call(5, -5, duration=1.0, button='right', mouseDownUp=False)]
+        )
+        self.mock.reset_mock()
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.drag_rel(5)
+        with self.assertRaises(MouseException):
+            self.lib.drag_rel(5, 5, duration='invalid')
+
+    def test_scroll(self):
+        self.lib.scroll('3')
+        self.assertEqual(self.mock.scroll.mock_calls, [call(3)])
+        self.mock.reset_mock()
+
+        self.lib.scroll(-5, 10, 20)
+        self.assertEqual(self.mock.scroll.mock_calls, [call(-5, x=10, y=20)])
+        self.mock.reset_mock()
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.scroll('foo')
+        with self.assertRaises(MouseException):
+            self.lib.scroll(1, 2)
+
+    def test_horizontal_scroll(self):
+        self.lib.scroll_horizontally('2')
+        self.assertEqual(self.mock.hscroll.mock_calls, [call(2)])
+        self.mock.reset_mock()
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.scroll_horizontally('foo')
+
+    def test_vertical_scroll(self):
+        self.lib.scroll_vertically('-3')
+        self.assertEqual(self.mock.vscroll.mock_calls, [call(-3)])
+        self.mock.reset_mock()
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.scroll_vertically('foo')
+
+    def test_global_pause_and_failsafe(self):
+        self.lib.set_global_pause('0.25')
+        self.assertEqual(self.mock.PAUSE, 0.25)
+
+        self.lib.set_failsafe('False')
+        self.assertFalse(self.mock.FAILSAFE)
+
+        from ImageHorizonLibrary import MouseException
+        with self.assertRaises(MouseException):
+            self.lib.set_global_pause('nope')
+        with self.assertRaises(MouseException):
+            self.lib.set_failsafe('maybe')


### PR DESCRIPTION
## Summary
- add helper utilities to the mouse mixin and expose new keywords for relative moves, drags, scrolling, and PyAutoGUI global settings
- document the new Robot Framework keywords in the README
- extend the mouse unit tests to cover the new behaviours and validation paths

## Testing
- pytest tests/utest/test_mouse.py

------
https://chatgpt.com/codex/tasks/task_e_68dc000c1000833387b9160068173fd9